### PR TITLE
add results='asis' to stargazer chunk header and others

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "index.Rmd"
 output:
-  pdf_document: default
   html_document: default
+  pdf_document: default
 ---
 
 ```{r setup, include=FALSE}
@@ -65,10 +65,11 @@ We have cleaned and merged the relevant data of both datasets. Then, we have gen
 ```
 
 ## Multiple Regression
-```{r , echo=FALSE, comment=NA, warning=FALSE, error=FALSE, message=FALSE}
+
+```{r , echo=FALSE, comment=NA, warning=FALSE, error=FALSE, message=FALSE, results='asis'}
 #Regression
 ##Data install
-data <- read.xlsx("/Users/komaiyumi/Desktop/Social Sicence/web/PISA_Data.xlsx",1)
+data <- read.xlsx("PISA_Data.xlsx",1)
 
 ##Conducting Regression
 ##Math
@@ -80,26 +81,12 @@ ma.lm3 <- lm(math ~ log(GDPperc) + log(pop) +  popd + rteacher + eyear + expend 
 mlabels <- c('log(GDPperc)', 'log(pop)','popd', 'rteacher', 'eyear', 'expend', 'internet','mobile','(intercept)')
 
 ###Create table
-stargazer(ma.lm,ma.lm2,ma.lm3, type='text',
-          covariate.labels = mlabels,
-          dep.var.labels = ('Math Score'),
-          out='math_regression.txt',
-          title="Table:Regression Estimates of Math Score",
-          no.space=TRUE)
-
-stargazer(ma.lm,ma.lm2,ma.lm3, type='latex', header = FALSE,
-          covariate.labels = mlabels,
-          dep.var.labels = ('Math Score'),
-          title="Table:Regression Estimates of Math Score",
-          no.space=TRUE)
-
 stargazer(ma.lm,ma.lm2,ma.lm3, type='html',
           covariate.labels = mlabels,
-          dep.var.labels = ('Math Score'),
-          out='math_regression.html',
+          dep.var.labels = 'Math Score',
           title="Table:Regression Estimates of Math Score")
 ```
-###Why can't I get a table on PDF??
+
 
 
 ```{r , echo=FALSE, comment=NA, warning=FALSE, error=FALSE, message=FALSE}


### PR DESCRIPTION
Added `results='asis'` to stargazer chunk header. As discussed in the lecture slides, this is needed to be able to return the raw code to the compiler so that it can be rendered in the document, rather than as a highlighted output code chunk.

Given that this for your website, I only included the `html` table stargazer call and changed the `output` type to `html_document` in the YAML header. 

Also, RMarkdown uses the `.Rmd` file's current directory as the working directory, therefore you do not need to set the absolute file path for data import calls. Using the relative file path makes it much easier to reproduce your document.